### PR TITLE
Corruption check

### DIFF
--- a/include/pelib/PeHeader.h
+++ b/include/pelib/PeHeader.h
@@ -1235,8 +1235,12 @@ namespace PeLib
 		// Verify the NT signature
 		if (header.Signature != PeLib::PELIB_IMAGE_NT_SIGNATURE)
 			setLoaderError(LDR_ERROR_NO_NT_SIGNATURE);
-		if (header.FileHeader.Machine == 0 || header.FileHeader.SizeOfOptionalHeader == 0)
+
+    // Zoo\PE-culiarities\ok_but_total_fuckups\SizeOfOptionalHeader_Zero\unpacked.ex_ 
+    // 7baebc6d9f2185fafa760c875ab1386f385a0b3fecf2e6ae339abb4d9ac58f3e
+    if (header.FileHeader.Machine == 0 && header.FileHeader.SizeOfOptionalHeader == 0)
 			setLoaderError(LDR_ERROR_FILE_HEADER_INVALID);
+
 		if (!(header.FileHeader.Characteristics & PeLib::PELIB_IMAGE_FILE_EXECUTABLE_IMAGE))
 			setLoaderError(LDR_ERROR_IMAGE_NON_EXECUTABLE);
 		if (header.OptionalHeader.Magic != PeLib::PELIB_IMAGE_NT_OPTIONAL_HDR32_MAGIC &&

--- a/include/pelib/PeHeader.h
+++ b/include/pelib/PeHeader.h
@@ -1236,9 +1236,9 @@ namespace PeLib
 		if (header.Signature != PeLib::PELIB_IMAGE_NT_SIGNATURE)
 			setLoaderError(LDR_ERROR_NO_NT_SIGNATURE);
 
-    // Zoo\PE-culiarities\ok_but_total_fuckups\SizeOfOptionalHeader_Zero\unpacked.ex_ 
-    // 7baebc6d9f2185fafa760c875ab1386f385a0b3fecf2e6ae339abb4d9ac58f3e
-    if (header.FileHeader.Machine == 0 && header.FileHeader.SizeOfOptionalHeader == 0)
+		// Zoo\PE-culiarities\ok_but_total_fuckups\SizeOfOptionalHeader_Zero\unpacked.ex_ 
+		// 7baebc6d9f2185fafa760c875ab1386f385a0b3fecf2e6ae339abb4d9ac58f3e
+		if (header.FileHeader.Machine == 0 && header.FileHeader.SizeOfOptionalHeader == 0)
 			setLoaderError(LDR_ERROR_FILE_HEADER_INVALID);
 
 		if (!(header.FileHeader.Characteristics & PeLib::PELIB_IMAGE_FILE_EXECUTABLE_IMAGE))

--- a/include/pelib/PeHeader.h
+++ b/include/pelib/PeHeader.h
@@ -1247,8 +1247,8 @@ namespace PeLib
 			header.OptionalHeader.Magic != PeLib::PELIB_IMAGE_NT_OPTIONAL_HDR64_MAGIC)
 			setLoaderError(LDR_ERROR_NO_OPTHDR_MAGIC);
 
-		// SizeOfHeaders must be nonzero
-		if(header.OptionalHeader.SizeOfHeaders == 0)
+		// SizeOfHeaders must be nonzero if not a single subsection
+		if(header.OptionalHeader.SectionAlignment >= PELIB_PAGE_SIZE && header.OptionalHeader.SizeOfHeaders == 0)
 			setLoaderError(LDR_ERROR_SIZE_OF_HEADERS_ZERO);
 
 		// File alignment must not be 0

--- a/include/pelib/PeHeader.h
+++ b/include/pelib/PeHeader.h
@@ -1236,7 +1236,6 @@ namespace PeLib
 		if (header.Signature != PeLib::PELIB_IMAGE_NT_SIGNATURE)
 			setLoaderError(LDR_ERROR_NO_NT_SIGNATURE);
 
-		// Zoo\PE-culiarities\ok_but_total_fuckups\SizeOfOptionalHeader_Zero\unpacked.ex_ 
 		// 7baebc6d9f2185fafa760c875ab1386f385a0b3fecf2e6ae339abb4d9ac58f3e
 		if (header.FileHeader.Machine == 0 && header.FileHeader.SizeOfOptionalHeader == 0)
 			setLoaderError(LDR_ERROR_FILE_HEADER_INVALID);


### PR DESCRIPTION
`IMAGE_FILE_HEADER::SizeOfOptionalHeader` can be 0, if `IMAGE_FILE_HEADER::Machine` is nonzero.
`IMAGE_OPTIONAL_HEADER::SizeOfHeaders` can be 0, if the file is single-section (`IMAGE_OPTIONAL_HEADER::SectionAlignment < PAGE_SIZE`)